### PR TITLE
Fix GHCR login step

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +26,12 @@ jobs:
             {{major}}
             {{major}}.{{minor}}
 
-      - run: echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - uses: docker/build-push-action@v4.0.0
         with:


### PR DESCRIPTION
## Summary
- fix GitHub Container Registry login step in `build_and_publish.yml`
- grant packages write permission

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684577ab2280832caec427f0ef1c668c