### PR TITLE
Add unit tests for clone_or_fetch_bare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "tempfile",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ structopt = "0.3"
 toml = "0.8"
 graphql_client = "0.14"
 
+[dev-dependencies]
+tempfile = "3"
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/src/clone_or_fetch_bare_tests.rs
+++ b/src/clone_or_fetch_bare_tests.rs
@@ -1,0 +1,90 @@
+use super::clone_or_fetch_bare;
+use git2::Repository;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn git(dir: Option<&Path>, args: &[&str]) {
+    let mut cmd = Command::new("git");
+    if let Some(d) = dir {
+        cmd.current_dir(d);
+    }
+    cmd.args(args);
+    let status = cmd.status().expect("git command");
+    assert!(status.success());
+}
+
+fn setup_remote() -> (TempDir, PathBuf, PathBuf) {
+    let temp = TempDir::new().unwrap();
+    let remote_dir = temp.path().join("remote.git");
+    git(None, &["init", "--bare", remote_dir.to_str().unwrap()]);
+
+    let work_dir = temp.path().join("work");
+    git(None, &["init", "-b", "master", work_dir.to_str().unwrap()]);
+    git(Some(&work_dir), &["config", "user.email", "test@example.com"]);
+    git(Some(&work_dir), &["config", "user.name", "Test"]);
+    git(Some(&work_dir), &["remote", "add", "origin", remote_dir.to_str().unwrap()]);
+    git(Some(&work_dir), &["commit", "--allow-empty", "-m", "init"]);
+    git(Some(&work_dir), &["push", "-u", "origin", "master"]);
+
+    (temp, remote_dir, work_dir)
+}
+
+fn head_commit(dir: &Path) -> String {
+    let output = Command::new("git")
+        .current_dir(dir)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn add_commit(dir: &Path, msg: &str) -> String {
+    git(Some(dir), &["commit", "--allow-empty", "-m", msg]);
+    git(Some(dir), &["push"]);
+    head_commit(dir)
+}
+
+#[test]
+fn dry_run_skips_clone() {
+    let (temp, remote, _work) = setup_remote();
+    let dest = temp.path().join("dest");
+
+    clone_or_fetch_bare(&dest, "repo", remote.to_str().unwrap(), true, None);
+
+    assert!(!dest.join("repo").exists());
+}
+
+#[test]
+fn clones_repository() {
+    let (temp, remote, work) = setup_remote();
+    let dest = temp.path().join("dest");
+    let first_commit = head_commit(&work);
+
+    clone_or_fetch_bare(&dest, "repo", remote.to_str().unwrap(), false, None);
+
+    let repo = Repository::open_bare(dest.join("repo")).unwrap();
+    let head = repo
+        .refname_to_id("refs/remotes/origin/master")
+        .unwrap();
+    assert_eq!(head.to_string(), first_commit);
+}
+
+#[test]
+fn fetches_updates() {
+    let (temp, remote, work) = setup_remote();
+    let dest = temp.path().join("dest");
+    clone_or_fetch_bare(&dest, "repo", remote.to_str().unwrap(), false, None);
+
+    let new_commit = add_commit(&work, "update");
+
+    clone_or_fetch_bare(&dest, "repo", remote.to_str().unwrap(), false, None);
+
+    let repo = Repository::open_bare(dest.join("repo")).unwrap();
+    let head = repo
+        .refname_to_id("refs/remotes/origin/master")
+        .unwrap();
+    assert_eq!(head.to_string(), new_commit);
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,3 +211,7 @@ fn clone_or_fetch_bare(
 		println!("Done")
 	}
 }
+
+
+#[cfg(test)]
+mod clone_or_fetch_bare_tests;


### PR DESCRIPTION
## Summary
- add `tempfile` dev dependency for tests
- create tests for `clone_or_fetch_bare` covering cloning, fetching, and dry run
- move tests into a separate file

## Testing
- `cargo test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68457a9c596c832cb6d60158fed1f0fd