### PR TITLE
Fix README badges for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The binary is available inside the `po4yka/gitout` Docker container which can ru
 [![Docker Image Size](https://img.shields.io/docker/image-size/po4yka/gitout)][layers]
 
  [hub]: https://hub.docker.com/r/po4yka/gitout/
- [layers]: https://microbadger.com/images/po4yka/gitout
+ [layers]: https://hub.docker.com/r/po4yka/gitout
 
 Mount a `/data` volume which is where the repositories will be stored.
 Mount the `/config` folder which contains a `config.toml` or mount a `/config/config.toml` file directly.


### PR DESCRIPTION
## Summary
- revert the Docker image name change
- update the badge link so Docker info works

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6845805a1890832cb182570146c74407