### PR TITLE
Fix startup arg mismatch

### DIFF
--- a/root/app/sync.sh
+++ b/root/app/sync.sh
@@ -8,7 +8,7 @@ fi
 set -e
 
 # shellcheck disable=SC2086
-/app/gitout --no-archive $GITOUT_ARGS /config/config.toml /data
+/app/gitout $GITOUT_ARGS /config/config.toml /data
 
 if [ -n "$HEALTHCHECK_ID" ]; then
 	curl -sS -X POST -o /dev/null --fail "$HEALTHCHECK_HOST/$HEALTHCHECK_ID"


### PR DESCRIPTION
## Summary
- remove deprecated `--no-archive` flag from startup script

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684bcd8cde78832c964619d079b83a76