### PR TITLE
Add CLI tests and enable CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,8 @@ jobs:
         toolchain: stable
     - uses: actions-rs/cargo@v1.0.3
       with:
+        command: test
+    - uses: actions-rs/cargo@v1.0.3
+      with:
         command: publish
         args: --dry-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -31,17 +72,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -69,12 +99,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -113,18 +137,49 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -309,7 +364,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "libc",
  "libgit2-sys",
  "log",
@@ -322,12 +377,12 @@ dependencies = [
 name = "gitout"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "git2",
  "graphql_client",
  "reqwest",
  "serde",
  "serde_json",
- "structopt",
  "tempfile",
  "toml",
 ]
@@ -417,27 +472,15 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "heck"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -691,6 +734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,12 +900,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -925,30 +980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1045,7 +1076,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1112,7 +1143,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1221,33 +1252,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1303,7 +1310,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1329,15 +1336,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1480,7 +1478,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -1536,18 +1534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,22 +1557,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1692,28 +1672,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1911,7 +1869,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ git2 = "0.20"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 toml = "0.8"
 graphql_client = "0.14"
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,56 +6,56 @@ use clap::Parser;
 #[command(author, version, about, long_about = None)]
 pub struct Args {
 	/// Configuration file
-        #[arg()]
-        pub config: PathBuf,
+	#[arg()]
+	pub config: PathBuf,
 
 	/// Backup directory
-        #[arg()]
-        pub destination: PathBuf,
+	#[arg()]
+	pub destination: PathBuf,
 
 	/// Enable verbose logging
-        #[arg(short, long)]
-        pub verbose: bool,
+	#[arg(short, long)]
+	pub verbose: bool,
 
 	/// Enable experimental repository archiving
-        #[arg(long)]
-        pub experimental_archive: bool,
+	#[arg(long)]
+	pub experimental_archive: bool,
 
 	/// Print actions instead of performing them
-        #[arg(long)]
-        pub dry_run: bool,
+	#[arg(long)]
+	pub dry_run: bool,
 }
 
 pub fn parse_args() -> Args {
-        Args::parse()
+	Args::parse()
 }
 
 #[cfg(test)]
 mod tests {
-        use super::*;
-        use clap::Parser;
+	use super::*;
+	use clap::Parser;
 
 	#[test]
-        fn parse_from_parses_all_flags() {
-                let args = Args::parse_from([
-                        "gitout",
-                        "config.toml",
-                        "dest",
-                        "-v",
-                        "--experimental-archive",
-                        "--dry-run",
-                ]);
+	fn parse_from_parses_all_flags() {
+		let args = Args::parse_from([
+			"gitout",
+			"config.toml",
+			"dest",
+			"-v",
+			"--experimental-archive",
+			"--dry-run",
+		]);
 
 		assert_eq!(args.config, PathBuf::from("config.toml"));
 		assert_eq!(args.destination, PathBuf::from("dest"));
 		assert!(args.verbose);
 		assert!(args.experimental_archive);
-                assert!(args.dry_run);
-        }
+		assert!(args.dry_run);
+	}
 
-        #[test]
-        fn parse_from_missing_required_args_errors() {
-                let result = Args::try_parse_from(["gitout"]); 
-                assert!(result.is_err());
-        }
+	#[test]
+	fn parse_from_missing_required_args_errors() {
+		let result = Args::try_parse_from(["gitout"]);
+		assert!(result.is_err());
+	}
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,54 +1,61 @@
 use std::path::PathBuf;
 
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, PartialEq, StructOpt)]
+#[derive(Debug, PartialEq, Parser)]
+#[command(author, version, about, long_about = None)]
 pub struct Args {
 	/// Configuration file
-	#[structopt(parse(from_os_str))]
-	pub config: PathBuf,
+        #[arg()]
+        pub config: PathBuf,
 
 	/// Backup directory
-	#[structopt(parse(from_os_str))]
-	pub destination: PathBuf,
+        #[arg()]
+        pub destination: PathBuf,
 
 	/// Enable verbose logging
-	#[structopt(short, long)]
-	pub verbose: bool,
+        #[arg(short, long)]
+        pub verbose: bool,
 
 	/// Enable experimental repository archiving
-	#[structopt(long)]
-	pub experimental_archive: bool,
+        #[arg(long)]
+        pub experimental_archive: bool,
 
 	/// Print actions instead of performing them
-	#[structopt(long)]
-	pub dry_run: bool,
+        #[arg(long)]
+        pub dry_run: bool,
 }
 
 pub fn parse_args() -> Args {
-	Args::from_args()
+        Args::parse()
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use structopt::StructOpt;
+        use super::*;
+        use clap::Parser;
 
 	#[test]
-	fn from_iter_parses_all_flags() {
-		let args = Args::from_iter(&[
-			"gitout",
-			"config.toml",
-			"dest",
-			"-v",
-			"--experimental-archive",
-			"--dry-run",
-		]);
+        fn parse_from_parses_all_flags() {
+                let args = Args::parse_from([
+                        "gitout",
+                        "config.toml",
+                        "dest",
+                        "-v",
+                        "--experimental-archive",
+                        "--dry-run",
+                ]);
 
 		assert_eq!(args.config, PathBuf::from("config.toml"));
 		assert_eq!(args.destination, PathBuf::from("dest"));
 		assert!(args.verbose);
 		assert!(args.experimental_archive);
-		assert!(args.dry_run);
-	}
+                assert!(args.dry_run);
+        }
+
+        #[test]
+        fn parse_from_missing_required_args_errors() {
+                let result = Args::try_parse_from(["gitout"]); 
+                assert!(result.is_err());
+        }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,139 +1,154 @@
 use git2::Repository;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::{fs};
 use tempfile::TempDir;
 
 fn git(dir: Option<&Path>, args: &[&str]) {
-    let mut cmd = Command::new("git");
-    if let Some(d) = dir {
-        cmd.current_dir(d);
-    }
-    cmd.args(args);
-    let status = cmd.status().expect("git command");
-    assert!(status.success());
+	let mut cmd = Command::new("git");
+	if let Some(d) = dir {
+		cmd.current_dir(d);
+	}
+	cmd.args(args);
+	let status = cmd.status().expect("git command");
+	assert!(status.success());
 }
 
 fn setup_remote() -> (TempDir, PathBuf, PathBuf) {
-    let temp = TempDir::new().unwrap();
-    let remote_dir = temp.path().join("remote.git");
-    git(None, &["init", "--bare", remote_dir.to_str().unwrap()]);
+	let temp = TempDir::new().unwrap();
+	let remote_dir = temp.path().join("remote.git");
+	git(None, &["init", "--bare", remote_dir.to_str().unwrap()]);
 
-    let work_dir = temp.path().join("work");
-    git(None, &["init", "-b", "master", work_dir.to_str().unwrap()]);
-    git(Some(&work_dir), &["config", "user.email", "test@example.com"]);
-    git(Some(&work_dir), &["config", "user.name", "Test"]);
-    git(Some(&work_dir), &["remote", "add", "origin", remote_dir.to_str().unwrap()]);
-    git(Some(&work_dir), &["commit", "--allow-empty", "-m", "init"]);
-    git(Some(&work_dir), &["push", "-u", "origin", "master"]);
+	let work_dir = temp.path().join("work");
+	git(None, &["init", "-b", "master", work_dir.to_str().unwrap()]);
+	git(
+		Some(&work_dir),
+		&["config", "user.email", "test@example.com"],
+	);
+	git(Some(&work_dir), &["config", "user.name", "Test"]);
+	git(
+		Some(&work_dir),
+		&["remote", "add", "origin", remote_dir.to_str().unwrap()],
+	);
+	git(Some(&work_dir), &["commit", "--allow-empty", "-m", "init"]);
+	git(Some(&work_dir), &["push", "-u", "origin", "master"]);
 
-    (temp, remote_dir, work_dir)
+	(temp, remote_dir, work_dir)
 }
 
 fn head_commit(dir: &Path) -> String {
-    let output = Command::new("git")
-        .current_dir(dir)
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .unwrap();
-    assert!(output.status.success());
-    String::from_utf8(output.stdout).unwrap().trim().to_string()
+	let output = Command::new("git")
+		.current_dir(dir)
+		.args(["rev-parse", "HEAD"])
+		.output()
+		.unwrap();
+	assert!(output.status.success());
+	String::from_utf8(output.stdout).unwrap().trim().to_string()
 }
 
 fn add_commit(dir: &Path, msg: &str) -> String {
-    git(Some(dir), &["commit", "--allow-empty", "-m", msg]);
-    git(Some(dir), &["push"]);
-    head_commit(dir)
+	git(Some(dir), &["commit", "--allow-empty", "-m", msg]);
+	git(Some(dir), &["push"]);
+	head_commit(dir)
 }
 
 #[test]
 fn binary_dry_run_skips_clone() {
-    let (temp, remote, _work) = setup_remote();
-    let dest = temp.path().join("dest");
-    fs::create_dir_all(&dest).unwrap();
-    let config = temp.path().join("config.toml");
-    fs::write(&config, format!(
-        "version = 0\n\n[git.repos]\nrepo = \"{}\"\n",
-        remote.to_str().unwrap()
-    ))
-    .unwrap();
+	let (temp, remote, _work) = setup_remote();
+	let dest = temp.path().join("dest");
+	fs::create_dir_all(&dest).unwrap();
+	let config = temp.path().join("config.toml");
+	fs::write(
+		&config,
+		format!(
+			"version = 0\n\n[git.repos]\nrepo = \"{}\"\n",
+			remote.to_str().unwrap()
+		),
+	)
+	.unwrap();
 
-    let status = Command::new(env!("CARGO_BIN_EXE_gitout"))
-        .arg("--dry-run")
-        .arg(&config)
-        .arg(&dest)
-        .status()
-        .expect("run gitout");
-    assert!(status.success());
+	let status = Command::new(env!("CARGO_BIN_EXE_gitout"))
+		.arg("--dry-run")
+		.arg(&config)
+		.arg(&dest)
+		.status()
+		.expect("run gitout");
+	assert!(status.success());
 
-    assert!(!dest.join("git").join("repo").exists());
+	assert!(!dest.join("git").join("repo").exists());
 }
 
 #[test]
 fn binary_clones_repository() {
-    let (temp, remote, work) = setup_remote();
-    let dest = temp.path().join("dest");
-    fs::create_dir_all(&dest).unwrap();
-    let config = temp.path().join("config.toml");
-    fs::write(&config, format!(
-        "version = 0\n\n[git.repos]\nrepo = \"{}\"\n",
-        remote.to_str().unwrap()
-    ))
-    .unwrap();
-    let first_commit = head_commit(&work);
+	let (temp, remote, work) = setup_remote();
+	let dest = temp.path().join("dest");
+	fs::create_dir_all(&dest).unwrap();
+	let config = temp.path().join("config.toml");
+	fs::write(
+		&config,
+		format!(
+			"version = 0\n\n[git.repos]\nrepo = \"{}\"\n",
+			remote.to_str().unwrap()
+		),
+	)
+	.unwrap();
+	let first_commit = head_commit(&work);
 
-    let status = Command::new(env!("CARGO_BIN_EXE_gitout"))
-        .arg(&config)
-        .arg(&dest)
-        .status()
-        .expect("run gitout");
-    assert!(status.success());
+	let status = Command::new(env!("CARGO_BIN_EXE_gitout"))
+		.arg(&config)
+		.arg(&dest)
+		.status()
+		.expect("run gitout");
+	assert!(status.success());
 
-    let repo = Repository::open_bare(dest.join("git").join("repo")).unwrap();
-    let head = repo.refname_to_id("refs/remotes/origin/master").unwrap();
-    assert_eq!(head.to_string(), first_commit);
+	let repo = Repository::open_bare(dest.join("git").join("repo")).unwrap();
+	let head = repo.refname_to_id("refs/remotes/origin/master").unwrap();
+	assert_eq!(head.to_string(), first_commit);
 }
 
 #[test]
 fn binary_fetches_updates() {
-    let (temp, remote, work) = setup_remote();
-    let dest = temp.path().join("dest");
-    fs::create_dir_all(&dest).unwrap();
-    let config = temp.path().join("config.toml");
-    fs::write(&config, format!(
-        "version = 0\n\n[git.repos]\nrepo = \"{}\"\n",
-        remote.to_str().unwrap()
-    ))
-    .unwrap();
-    let first_status = Command::new(env!("CARGO_BIN_EXE_gitout"))
-        .arg(&config)
-        .arg(&dest)
-        .status()
-        .expect("run gitout");
-    assert!(first_status.success());
+	let (temp, remote, work) = setup_remote();
+	let dest = temp.path().join("dest");
+	fs::create_dir_all(&dest).unwrap();
+	let config = temp.path().join("config.toml");
+	fs::write(
+		&config,
+		format!(
+			"version = 0\n\n[git.repos]\nrepo = \"{}\"\n",
+			remote.to_str().unwrap()
+		),
+	)
+	.unwrap();
+	let first_status = Command::new(env!("CARGO_BIN_EXE_gitout"))
+		.arg(&config)
+		.arg(&dest)
+		.status()
+		.expect("run gitout");
+	assert!(first_status.success());
 
-    let new_commit = add_commit(&work, "update");
+	let new_commit = add_commit(&work, "update");
 
-    let second_status = Command::new(env!("CARGO_BIN_EXE_gitout"))
-        .arg(&config)
-        .arg(&dest)
-        .status()
-        .expect("run gitout");
-    assert!(second_status.success());
+	let second_status = Command::new(env!("CARGO_BIN_EXE_gitout"))
+		.arg(&config)
+		.arg(&dest)
+		.status()
+		.expect("run gitout");
+	assert!(second_status.success());
 
-    let repo = Repository::open_bare(dest.join("git").join("repo")).unwrap();
-    let head = repo.refname_to_id("refs/remotes/origin/master").unwrap();
-    assert_eq!(head.to_string(), new_commit);
+	let repo = Repository::open_bare(dest.join("git").join("repo")).unwrap();
+	let head = repo.refname_to_id("refs/remotes/origin/master").unwrap();
+	assert_eq!(head.to_string(), new_commit);
 }
 
 #[test]
 fn binary_prints_version() {
-    let output = Command::new(env!("CARGO_BIN_EXE_gitout"))
-        .arg("--version")
-        .output()
-        .expect("run gitout");
-    assert!(output.status.success());
+	let output = Command::new(env!("CARGO_BIN_EXE_gitout"))
+		.arg("--version")
+		.output()
+		.expect("run gitout");
+	assert!(output.status.success());
 
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
+	let stdout = String::from_utf8(output.stdout).unwrap();
+	assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -125,3 +125,15 @@ fn binary_fetches_updates() {
     let head = repo.refname_to_id("refs/remotes/origin/master").unwrap();
     assert_eq!(head.to_string(), new_commit);
 }
+
+#[test]
+fn binary_prints_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_gitout"))
+        .arg("--version")
+        .output()
+        .expect("run gitout");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
+}


### PR DESCRIPTION
## Summary
- add clap metadata to restore `--version`
- test missing arg case and version flag
- run `cargo test` in CI to ensure checks

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684d595271b4832c815db6313bb6d682