### PR TITLE
Add CLI flags for repo categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ A command-line tool to automatically backup Git repositories from GitHub or anyw
 The `gitout` tool will clone git repos from GitHub or any other git hosting service.
 If the repository was already cloned, it will fetch any updates to keep your local copy in sync.
 
-When you add your GitHub username and a token, `gitout` will discover all of your owned repositories and synchronize them automatically.
-You can opt-in to having repositories that you've starred or watched synchronized as well.
+When you add your GitHub username and a token, `gitout` can discover your repositories.
+Use the `--owned`, `--starred` (or `--stars`), and `--watched` flags to specify which
+repositories are synchronized. When a flag is omitted the behavior falls back to the
+values configured in `config.toml`.
 
 The cloned repositories are [bare](https://www.saintsjd.com/2011/01/what-is-a-bare-git-repository/).
 In other words, there is no working copy of the files for you to interact with.
@@ -42,7 +44,8 @@ $ docker run -d \
     -v /path/to/data:/data \
     -v /path/to/config.toml:/config/config.toml \
     -e "CRON=0 * * * *" \
-    po4yka/gitout
+    po4yka/gitout \
+    --owned --starred --watched
 ```
 
 For help creating a valid cron specifier, visit [cron.help](https://cron.help/#0_*_*_*_*).
@@ -60,6 +63,7 @@ services:
     volumes:
       - /path/to/data:/data
       - /path/to/config:/config
+    command: --owned --starred --watched
     environment:
       - "CRON=0 * * * *"
       #Optional:
@@ -115,19 +119,21 @@ Usage
 $ gitout --help
 gitout 0.2.0
 
-USAGE:
-    gitout [FLAGS] <config> <destination>
+Usage: gitout [OPTIONS] <CONFIG> <DESTINATION>
 
-FLAGS:
-        --dry-run                 Print actions instead of performing them
-        --experimental-archive    Enable experimental repository archiving
-    -h, --help                    Prints help information
-    -V, --version                 Prints version information
-    -v, --verbose                 Enable verbose logging
+Arguments:
+  <CONFIG>       Configuration file
+  <DESTINATION>  Backup directory
 
-ARGS:
-    <config>         Configuration file
-    <destination>    Backup directory
+Options:
+  -v, --verbose               Enable verbose logging
+      --experimental-archive  Enable experimental repository archiving
+      --dry-run               Print actions instead of performing them
+      --owned                 Include repositories you own
+      --starred               Include repositories you have starred
+      --watched               Include repositories you watch
+  -h, --help                  Print help
+  -V, --version               Print version
 ```
 
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -24,6 +24,18 @@ pub struct Args {
     /// Print actions instead of performing them
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Include repositories you own
+    #[arg(long)]
+    pub owned: bool,
+
+    /// Include repositories you have starred
+    #[arg(long, alias = "stars")]
+    pub starred: bool,
+
+    /// Include repositories you watch
+    #[arg(long)]
+    pub watched: bool,
 }
 
 pub fn parse_args() -> Args {
@@ -44,6 +56,9 @@ mod tests {
             "-v",
             "--experimental-archive",
             "--dry-run",
+            "--owned",
+            "--stars",
+            "--watched",
         ]);
 
         assert_eq!(args.config, PathBuf::from("config.toml"));
@@ -51,6 +66,9 @@ mod tests {
         assert!(args.verbose);
         assert!(args.experimental_archive);
         assert!(args.dry_run);
+        assert!(args.owned);
+        assert!(args.starred);
+        assert!(args.watched);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@ fn main() {
         verbose,
         experimental_archive,
         dry_run,
+        owned,
+        starred,
+        watched,
     } = args;
 
     if !dry_run {
@@ -31,7 +34,15 @@ fn main() {
     }
 
     let config = fs::read_to_string(config).unwrap();
-    let config = config::parse_config(&config).unwrap();
+    let mut config = config::parse_config(&config).unwrap();
+    if let Some(ref mut github) = config.github {
+        if starred {
+            github.clone.starred = true;
+        }
+        if watched {
+            github.clone.watched = true;
+        }
+    }
     if verbose {
         dbg!(&config);
     }
@@ -107,7 +118,9 @@ fn main() {
         clone_dir.push("clone");
 
         let mut clone_repos = vec![];
-        clone_repos.extend(user_repos.owned.clone());
+        if owned {
+            clone_repos.extend(user_repos.owned.clone());
+        }
         clone_repos.extend(archive_repos);
         clone_repos.extend(github.clone.repos.clone());
         if github.clone.starred {


### PR DESCRIPTION
## Summary
- support `--owned`, `--stars`, and `--watched` CLI flags
- wire flags into config and repo selection logic
- update argument parsing tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d9418aee0832cb3c0685ccdd126da