### PR TITLE
Add CLI support for --dest

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Parser, Error};
+use clap::{Error, Parser};
 use std::ffi::OsString;
 
 #[derive(Debug, PartialEq, Parser)]
@@ -138,12 +138,7 @@ mod tests {
 
     #[test]
     fn parse_from_dest_flag() {
-        let args = parse_from([
-            "gitout",
-            "--dest",
-            "out",
-            "config.toml",
-        ]);
+        let args = parse_from(["gitout", "--dest", "out", "config.toml"]);
 
         assert_eq!(args.destination, PathBuf::from("out"));
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,55 +1,114 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Parser, Error};
+use std::ffi::OsString;
 
 #[derive(Debug, PartialEq, Parser)]
 #[command(author, version, about, long_about = None)]
-pub struct Args {
+struct CliArgs {
     /// Configuration file
     #[arg(value_parser)]
-    pub config: PathBuf,
+    config: PathBuf,
 
     /// Backup directory
-    #[arg(value_parser)]
-    pub destination: PathBuf,
+    #[arg(value_parser, required_unless_present = "dest")]
+    destination: Option<PathBuf>,
+
+    /// Backup directory (deprecated flag)
+    #[arg(long, hide = true)]
+    dest: Option<PathBuf>,
 
     /// Enable verbose logging
     #[arg(short, long)]
-    pub verbose: bool,
+    verbose: bool,
 
     /// Enable experimental repository archiving
     #[arg(long)]
-    pub experimental_archive: bool,
+    experimental_archive: bool,
 
     /// Print actions instead of performing them
     #[arg(long)]
-    pub dry_run: bool,
+    dry_run: bool,
 
     /// Include repositories you own
     #[arg(long)]
-    pub owned: bool,
+    owned: bool,
 
     /// Include repositories you have starred
     #[arg(long, alias = "stars")]
-    pub starred: bool,
+    starred: bool,
 
     /// Include repositories you watch
     #[arg(long)]
+    watched: bool,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Args {
+    pub config: PathBuf,
+    pub destination: PathBuf,
+    pub verbose: bool,
+    pub experimental_archive: bool,
+    pub dry_run: bool,
+    pub owned: bool,
+    pub starred: bool,
     pub watched: bool,
 }
 
 pub fn parse_args() -> Args {
-    Args::parse()
+    match parse_args_from(std::env::args_os()) {
+        Ok(a) => a,
+        Err(e) => e.exit(),
+    }
+}
+
+pub fn parse_args_from<I, T>(itr: I) -> Result<Args, Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let cli = CliArgs::try_parse_from(itr)?;
+    let destination = cli.dest.or(cli.destination).unwrap();
+    Ok(Args {
+        config: cli.config,
+        destination,
+        verbose: cli.verbose,
+        experimental_archive: cli.experimental_archive,
+        dry_run: cli.dry_run,
+        owned: cli.owned,
+        starred: cli.starred,
+        watched: cli.watched,
+    })
+}
+
+#[cfg(test)]
+pub fn try_parse_from<I, T>(itr: I) -> Result<Args, Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    parse_args_from(itr)
+}
+
+#[cfg(test)]
+pub fn parse_from<I, T>(itr: I) -> Args
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    match parse_args_from(itr) {
+        Ok(a) => a,
+        Err(e) => e.exit(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
 
     #[test]
     fn parse_from_parses_all_flags() {
-        let args = Args::parse_from([
+        let args = parse_from([
             "gitout",
             "config.toml",
             "dest",
@@ -73,7 +132,19 @@ mod tests {
 
     #[test]
     fn parse_from_missing_required_args_errors() {
-        let result = Args::try_parse_from(["gitout"]);
+        let result = try_parse_from(["gitout"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_from_dest_flag() {
+        let args = parse_from([
+            "gitout",
+            "--dest",
+            "out",
+            "config.toml",
+        ]);
+
+        assert_eq!(args.destination, PathBuf::from("out"));
     }
 }


### PR DESCRIPTION
## Summary
- add `--dest` as an optional alias for the destination argument
- handle both positional and flag forms in argument parser
- adjust unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684da9d62df0832c9cb6e94b5088e56e