### PR TITLE
Improve error handling to prevent panics

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -122,7 +122,8 @@ pub fn archive_repo(client: &Client, dir: &Path, repository: &str, token: &str) 
             break;
         }
         if migration_state == "failed" {
-            panic!("Creating migration for {} failed", &repository);
+            eprintln!("Creating migration for {} failed", &repository);
+            return;
         }
 
         thread::sleep(wait);

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,25 +60,49 @@ fn sync_once(args: &args::Args) {
     } = args.clone();
 
     if !dry_run {
-        let destination_metadata = fs::metadata(&destination).unwrap();
+        let destination_metadata = match fs::metadata(&destination) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("Failed to access destination {:?}: {}", destination, e);
+                return;
+            }
+        };
         if !destination_metadata.is_dir() {
-            panic!("Destination must exist and must be a directory")
+            eprintln!("Destination must exist and must be a directory");
+            return;
         }
     }
 
     // Check if config path exists and is a file
-    let config_metadata = fs::metadata(&config_path)
-        .unwrap_or_else(|e| panic!("Failed to access config file at {:?}: {}", config_path, e));
+    let config_metadata = match fs::metadata(&config_path) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("Failed to access config file at {:?}: {}", config_path, e);
+            return;
+        }
+    };
     if config_metadata.is_dir() {
-        panic!(
+        eprintln!(
             "Config path {:?} is a directory, but must be a file",
             config_path
         );
+        return;
     }
 
-    let config = fs::read_to_string(&config_path)
-        .unwrap_or_else(|e| panic!("Failed to read config file at {:?}: {}", config_path, e));
-    let mut config = config::parse_config(&config).unwrap();
+    let config = match fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to read config file at {:?}: {}", config_path, e);
+            return;
+        }
+    };
+    let mut config = match config::parse_config(&config) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to parse config file at {:?}: {}", config_path, e);
+            return;
+        }
+    };
     if let Some(ref mut github) = config.github {
         if starred {
             github.clone.starred = true;


### PR DESCRIPTION
## Summary
- add checks for destination and config path
- avoid panicking when archive migration fails

## Testing
- `cargo test --quiet`
- `cargo fmt -- --check`


------
https://chatgpt.com/codex/tasks/task_e_684ee9bc3ddc832ca21b5718b6be68bc