### PR TITLE
Fix SSL CA setup for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,10 @@ FROM debian:bookworm-slim
 ARG TARGETARCH
 RUN apt-get update && \
     apt-get install -y --no-install-recommends bash ca-certificates curl xz-utils && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    update-ca-certificates
+
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ARG S6_OVERLAY_VERSION=3.2.1.0
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp/
 RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz


### PR DESCRIPTION
## Summary
- ensure `ca-certificates` installed and update CA store
- set `SSL_CERT_FILE` path so git operations succeed

## Testing
- `cargo test` *(fails: could not compile `gitout` due to errors)*

------
https://chatgpt.com/codex/tasks/task_e_684fa4f0b994832cb2584f4fe81d26c3