### PR TITLE
Fix GitHub API version

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -22,7 +22,9 @@ const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PK
 /// Accept header required for user migrations API.
 /// https://docs.github.com/rest/migrations/users#start-a-user-migration
 const GITHUB_ACCEPT: &str = "application/vnd.github.wyandotte-preview+json";
-const GITHUB_API_VERSION: &str = "2025-06-04";
+/// API version header for GitHub requests.
+/// The migrations API only supports the 2022-11-28 version as of now.
+const GITHUB_API_VERSION: &str = "2022-11-28";
 
 pub struct GitHub {
     client: Client,

--- a/src/github.rs
+++ b/src/github.rs
@@ -143,6 +143,12 @@ impl GitHub {
                     repo = repository,
                     error = e
                 );
+                if let Some(status) = e.status() {
+                    eprintln!("GitHub API status: {status}");
+                }
+                if let Some(url) = e.url() {
+                    eprintln!("GitHub API URL: {url}");
+                }
                 return;
             }
         };
@@ -190,6 +196,12 @@ impl GitHub {
                         repo = repository,
                         error = e
                     );
+                    if let Some(status) = e.status() {
+                        eprintln!("GitHub API status: {status}");
+                    }
+                    if let Some(url) = e.url() {
+                        eprintln!("GitHub API URL: {url}");
+                    }
                     return;
                 }
             };
@@ -240,6 +252,12 @@ impl GitHub {
                     repo = repository,
                     error = e
                 );
+                if let Some(status) = e.status() {
+                    eprintln!("GitHub API status: {status}");
+                }
+                if let Some(url) = e.url() {
+                    eprintln!("GitHub API URL: {url}");
+                }
                 return;
             }
         };


### PR DESCRIPTION
## Summary
- fix GitHub API version header so user migrations use a supported API

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684fd29c3abc832c9aec665cad85af56