### PR TITLE
Update GitHub migration header and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,14 +289,15 @@ locations such as `/etc/ssl/certs/ca-certificates.crt` and `/usr/lib/ssl/cert.pe
 
 ### Creating a GitHub token
 
-  1. Visit https://github.com/settings/tokens
-  2. Click "Generate new token"
-  3. Type "gitout" in the name field
-  4. Select the "repo", "gist", and "read:user" scopes
+1. Visit https://github.com/settings/tokens
+2. Click "Generate new token" under **"Personal access tokens (classic)"**
+3. Type "gitout" in the name field
+4. Select the "repo", "gist", and "read:user" scopes
      - `repo`: Needed to discover and clone private repositories (if you only have public repositories then just `public_repo` will also work)
      - `gist`: Needed to discover and clone private gists (if you only have public gists then this is not required)
      - `read:user`: Needed to traverse your owned, starred, and watched repo lists
-  5. Select "Generate token"
+   - *Fine-grained personal access tokens are **not** supported by the GitHub migrations API.* Use a classic token instead.
+5. Select "Generate token"
   6. Copy the value into your `config.toml` as it will not be shown again
 
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -21,7 +21,7 @@ struct UserRepos;
 const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 /// Accept header required for user migrations API.
 /// https://docs.github.com/rest/migrations/users#start-a-user-migration
-const GITHUB_ACCEPT: &str = "application/vnd.github.wyandotte-preview+json";
+const GITHUB_ACCEPT: &str = "application/vnd.github+json";
 /// API version header for GitHub requests.
 /// The migrations API only supports the 2022-11-28 version as of now.
 const GITHUB_API_VERSION: &str = "2022-11-28";


### PR DESCRIPTION
## Summary
- use the recommended `application/vnd.github+json` header for migrations
- clarify that GitHub migrations require a classic PAT

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684fded16334832c9874d3eff319f394